### PR TITLE
Sheldon lockの際にプラグインがダウンロードされない

### DIFF
--- a/run_once_install.sh.tmpl
+++ b/run_once_install.sh.tmpl
@@ -24,14 +24,6 @@
 echo "Operating System is {{$platform}}"
 
 # ---------------------------------------------------------
-# Create ~/.local/share/sheldon/repo/
-# sheldonでgitリポジトリがcloneできない問題に対する対症療法
-# Permissionの問題？先にディレクトリを作成しておく
-# 解決したら削除する
-# ---------------------------------------------------------
-mkdir -p ~/.local/share/sheldon/repo/
-
-# ---------------------------------------------------------
 # Install packages for each platform
 # ---------------------------------------------------------
 {{ .chezmoi.sourceDir }}/scripts/install-{{$platform}}.sh

--- a/run_once_install.sh.tmpl
+++ b/run_once_install.sh.tmpl
@@ -24,6 +24,14 @@
 echo "Operating System is {{$platform}}"
 
 # ---------------------------------------------------------
+# Create ~/.local/share/sheldon/repo/
+# sheldonでgitリポジトリがcloneできない問題に対する対症療法
+# Permissionの問題？先にディレクトリを作成しておく
+# 解決したら削除する
+# ---------------------------------------------------------
+mkdir -p ~/.local/share/sheldon/repo/
+
+# ---------------------------------------------------------
 # Install packages for each platform
 # ---------------------------------------------------------
 {{ .chezmoi.sourceDir }}/scripts/install-{{$platform}}.sh

--- a/scripts/install-rust.sh
+++ b/scripts/install-rust.sh
@@ -19,11 +19,12 @@ cargo binstall -q -y --only-signed bp \
 	cargo-update \
 	eza \
 	git-delta \
-	sheldon \
 	starship \
 	topgrade \
 	xcp \
 	zoxide
+
+cargo install -q --locked sheldon --version 0.7.4
 
 # Install Trashy (Linux only)
 if [ "$(uname)" == "Linux" ]; then


### PR DESCRIPTION
sheldon lockの際に

```
ERROR: failed to install source `https://github.com/romkatv/zsh-defer`
  due to: failed to git clone `https://github.com/romkatv/zsh-defer`
  due to: cannot access component in path '/github/home/.local/share/sheldon/repos': ; class=Os (2)
```

が表示される。
dockerで検証したところ、先に上記ディレクトリを作成しておくとエラーが出なかったので、先に作成してActionsが通るか検証
