### PR TITLE
feat: Improve zsh startup performance with zsh-defer

### DIFF
--- a/dot_config/sheldon/plugins.toml
+++ b/dot_config/sheldon/plugins.toml
@@ -49,7 +49,7 @@ apply = ["defer"]
 
 [plugins.completions]
 local = "~/.config/zsh/completions"
-apply = ["fpath"]
+apply = ["fpath", "defer"]
 
 [plugins.compinit]
 inline = "autoload -Uz compinit && zsh-defer compinit -C"
@@ -71,4 +71,4 @@ apply = ["defer"]
 [plugins.dotfiles-custom_command]
 local = "~/.config/zsh/custom_command"
 use = ["*.zsh"]
-apply = ["source"]
+apply = ["defer"]

--- a/dot_config/zsh/dot_zshrc
+++ b/dot_config/zsh/dot_zshrc
@@ -30,4 +30,4 @@ eval "$(starship init zsh)"
 # ---------------------------------------------------------
 # Mise
 # ---------------------------------------------------------
-eval "$(mise activate zsh)"
+zsh-defer eval "$(mise activate zsh)"


### PR DESCRIPTION
## Summary
- Add `defer` apply option to completions and custom_command plugins in sheldon configuration
- Defer mise activation using `zsh-defer` to improve shell startup time
- Optimize zsh loading performance by deferring non-critical components

## Test plan
- [ ] Verify zsh still loads correctly with all functionality intact
- [ ] Test that completions work as expected after deferred loading
- [ ] Confirm custom commands are available after startup
- [ ] Measure zsh startup time improvement

🤖 Generated with [Claude Code](https://claude.ai/code)