### PR TITLE
fix: Disable termsync to resolve Wezterm-Neovim rendering issues

### DIFF
--- a/dot_config/nvim/lua/plugins/astrocore.lua
+++ b/dot_config/nvim/lua/plugins/astrocore.lua
@@ -43,6 +43,7 @@ return {
         spell = false, -- sets vim.opt.spell
         signcolumn = "yes", -- sets vim.opt.signcolumn to yes
         wrap = false, -- sets vim.opt.wrap
+        termsync = false, -- Fix problem(https://github.com/wezterm/wezterm/issues/4607)
       },
       g = { -- vim.g.<key>
         -- configure global vim variables (vim.g)


### PR DESCRIPTION
## Summary
- Disabled `termsync` option in Neovim configuration to fix rendering issues with Wezterm terminal

## Test plan
- [x] Verify Neovim starts without rendering issues in Wezterm
- [x] Confirm no regression in other terminal emulators

🤖 Generated with [Claude Code](https://claude.ai/code)