### PR TITLE
fix(ci): add HOMEBREW_GITHUB_API_TOKEN and MISE_GITHUB_TOKEN to resolve GitHub API rate limiting

### DIFF
--- a/.github/workflows/arch_manjaro.yml
+++ b/.github/workflows/arch_manjaro.yml
@@ -12,6 +12,9 @@ jobs:
     # if: ${{ contains(github.event.head_commit.message, "[CI]") }}
     container:
       image: archlinux:latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      MISE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v3
       - name: Extract branch name for push
@@ -34,8 +37,6 @@ jobs:
             sudo git curl \
             base-devel pkgconf oniguruma
       - name: Run chezmoi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: sh -c "$(curl -fsLS chezmoi.io/get)" -- init --apply --branch ${{ env.CURRENT_BRANCH }} radiol
       # # Error Check
       - name: Exec zsh and check sheldon/plugins.lock exist.
@@ -63,6 +64,9 @@ jobs:
     # if: ${{ contains(github.event.head_commit.message, "[CI]") }}
     container:
       image: manjarolinux/base:latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      MISE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v3
       - name: Extract branch name for push
@@ -87,8 +91,6 @@ jobs:
             sudo git curl \
             base-devel pkgconf oniguruma
       - name: Run chezmoi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: sh -c "$(curl -fsLS chezmoi.io/get)" -- init --apply --branch ${{ env.CURRENT_BRANCH }} radiol
       # # Error Check
       - name: Exec zsh and check sheldon/plugins.lock exist.

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: macos-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      MISE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v3
       - name: Extract branch name for push

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -11,6 +11,10 @@ concurrency: dotfiles-test-ubuntu
 jobs:
   ubuntu-test:
     runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      MISE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v3
 
@@ -35,8 +39,6 @@ jobs:
 
       - name: Run chezmoi
         shell: bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           /bin/bash -c "$(curl -fsLS chezmoi.io/get)" -- init --apply --branch "${{ env.CURRENT_BRANCH }}" radiol


### PR DESCRIPTION
## 概要

全CIワークフローで `mise use --global neovim` 等がHTTP 403で失敗する問題を修正する。
`GITHUB_TOKEN` は設定済みだが、Homebrew と mise の vfox バックエンドはそれぞれ専用の環境変数を必要とするため、全ワークフローに追加する。

## 変更内容

- `macos.yml`: `HOMEBREW_GITHUB_API_TOKEN` と `MISE_GITHUB_TOKEN` を job レベルに追加
- `ubuntu.yml`: 同上（`GITHUB_TOKEN` も step レベルから job レベルに移動）
- `arch_manjaro.yml`: `MISE_GITHUB_TOKEN` を arch/manjaro 両ジョブに追加（`GITHUB_TOKEN` も job レベルに移動）

## 動作確認

- CI の各ワークフローで API rate limit / HTTP 403 が発生しないことを確認予定