### PR TITLE
refactor(install): move neovim install from mise to brew/pacman

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -41,6 +41,12 @@ jobs:
           set -euo pipefail
           /bin/bash -c "$(curl -fsLS chezmoi.io/get)" -- init --apply --branch "${{ env.CURRENT_BRANCH }}" radiol
 
+      - name: Set up linuxbrew PATH
+        shell: bash
+        run: |
+          echo "/home/linuxbrew/.linuxbrew/bin" >> "$GITHUB_PATH"
+          echo "/home/linuxbrew/.linuxbrew/sbin" >> "$GITHUB_PATH"
+
       - name: Exec zsh and check sheldon/plugins.lock exist.
         shell: bash
         run: |

--- a/scripts/brew.sh
+++ b/scripts/brew.sh
@@ -44,6 +44,7 @@ brew install -q \
   jq \
   lazygit \
   luarocks \
+  neovim \
   node \
   openssl@3 \
   readline \

--- a/scripts/mise.sh
+++ b/scripts/mise.sh
@@ -32,7 +32,6 @@ MISE="${HOME}/.local/bin/mise"
 "${MISE}" use --global jujutsu
 "${MISE}" use --global lefthook
 "${MISE}" use --global lua@5.4
-"${MISE}" use --global neovim
 "${MISE}" use --global ripgrep
 "${MISE}" use --global usage
 "${MISE}" use --global yazi

--- a/scripts/pacman.sh
+++ b/scripts/pacman.sh
@@ -7,13 +7,13 @@ echo "::group:: Pacman Install Apps"
 
 # Edit /etc/pacman.conf
 if grep -q "#Color" /etc/pacman.conf; then
-	echo "Setting pacman color"
-	sudo sed -i "s/#Color/Color/" /etc/pacman.conf
+  echo "Setting pacman color"
+  sudo sed -i "s/#Color/Color/" /etc/pacman.conf
 fi
 
 if ! grep -q "ILoveCandy" /etc/pacman.conf; then
-	echo "Setting pacman ILoveCandy"
-	sudo sed -i "/VerbosePkgLists/a ILoveCandy" /etc/pacman.conf
+  echo "Setting pacman ILoveCandy"
+  sudo sed -i "/VerbosePkgLists/a ILoveCandy" /etc/pacman.conf
 fi
 
 # Update
@@ -26,27 +26,28 @@ LANG=C xdg-user-dirs-gtk-update --noconfirm
 # Install applications
 echo "Installing Apps with Pacman"
 sudo pacman -Sy -q --noconfirm \
-	base-devel \
-	cmake \
-	curl \
-	direnv \
-	fd \
-	fzf \
-	gcc \
-	git \
-	go \
-	gopass \
-	jq \
-	lazygit \
-	luarocks \
-	nodejs \
-	noto-fonts-emoji \
-	openssl \
-	openssh \
-	ufw \
-	unzip \
-	wezterm \
-	xclip \
-	zsh
+  base-devel \
+  cmake \
+  curl \
+  direnv \
+  fd \
+  fzf \
+  gcc \
+  git \
+  go \
+  gopass \
+  jq \
+  lazygit \
+  luarocks \
+  neovim \
+  nodejs \
+  noto-fonts-emoji \
+  openssl \
+  openssh \
+  ufw \
+  unzip \
+  wezterm \
+  xclip \
+  zsh
 
 echo "::endgroup::"


### PR DESCRIPTION
## 概要

mise の vfox バックエンドが GitHub API 認証を正しく処理できず、neovim のインストールが HTTP 403 で失敗するため、各プラットフォームのパッケージマネージャーでインストールするよう変更する。

## 変更内容

- `mise.sh`: `mise use --global neovim` を削除
- `brew.sh`: `neovim` を追加（macOS / ubuntu 対象）
- `pacman.sh`: `neovim` を追加（arch / manjaro 対象）
- `ubuntu.yml`: chezmoi 実行後に linuxbrew の PATH を追加（nvim が後続ステップで見つかるよう）

## 動作確認

- CI の全ワークフローで neovim が正常にインストールされることを確認予定