### PR TITLE
feat(mise): add python as global mise tool

### DIFF
--- a/scripts/mise.sh
+++ b/scripts/mise.sh
@@ -32,6 +32,7 @@ MISE="${HOME}/.local/bin/mise"
 "${MISE}" use --global jujutsu
 "${MISE}" use --global lefthook
 "${MISE}" use --global lua@5.4
+"${MISE}" use --global python
 "${MISE}" use --global ripgrep
 "${MISE}" use --global usage
 "${MISE}" use --global yazi


### PR DESCRIPTION
## 概要

mise でグローバルにインストールするツールに `python` を追加する。

## 変更内容

- `scripts/mise.sh` に `"${MISE}" use --global python` を追加

## 動作確認

- スクリプト実行時に python が mise 経由でインストールされることを確認