### PR TITLE
feat(keymaps): add floating terminal toggle with <C-t>

### DIFF
--- a/dot_config/lazyvim/lua/config/keymaps.lua
+++ b/dot_config/lazyvim/lua/config/keymaps.lua
@@ -1,3 +1,10 @@
 -- Keymaps are automatically loaded on the VeryLazy event
 -- Default keymaps that are always set: https://github.com/LazyVim/LazyVim/blob/main/lua/lazyvim/config/keymaps.lua
 -- Add any additional keymaps here
+local map = vim.keymap.set
+
+--local uname = vim.uv.os_uname()
+
+map({ "n", "t" }, "<C-t>", function()
+  Snacks.terminal.toggle(nil, { win = { position = "float" } })
+end, { desc = "Toggle floating terminal" })


### PR DESCRIPTION
## 概要

Snacks.terminalを使ったフローティングターミナルのトグルキーマップ (<C-t>) を追加する。

## 変更内容

- `lua/config/keymaps.lua` に `<C-t>` でフローティングターミナルをトグルするキーマップを追加
- ノーマルモード・ターミナルモード両方で動作

## 動作確認

- <C-t> でフローティングターミナルが開閉することを確認