### PR TITLE
chore(rust): add cargo development tools and fix indentation

### DIFF
--- a/scripts/rust.sh
+++ b/scripts/rust.sh
@@ -6,10 +6,10 @@
 echo "::group::Install Rust"
 
 if ! (type "cargo" >/dev/null 2>&1); then
-	echo "Installing Rust"
-	curl --proto '=https' --tlsv1.2 https://sh.rustup.rs >rustup.sh
-	sh rustup.sh -y -q --no-modify-path && rm rustup.sh
-	source "$HOME/.cargo/env"
+  echo "Installing Rust"
+  curl --proto '=https' --tlsv1.2 https://sh.rustup.rs >rustup.sh
+  sh rustup.sh -y -q --no-modify-path && rm rustup.sh
+  source "$HOME/.cargo/env"
 fi
 
 # Install Rust Apps
@@ -17,15 +17,20 @@ echo "Installing cargo-binstall"
 cargo install -q cargo-binstall
 echo "Installing Rust Apps"
 cargo-binstall -q -y --only-signed --locked \
-	bp \
-	cargo-edit \
-	cargo-update \
-	eza \
-	git-delta \
-	starship \
-	topgrade \
-	xcp \
-	zoxide
+  bp \
+  cargo-edit \
+  cargo-update \
+  cargo-udeps \
+  cargo-watch \
+  cargo-nextest \
+  cargo-audit \
+  cargo-release \
+  eza \
+  git-delta \
+  starship \
+  topgrade \
+  xcp \
+  zoxide
 
 cargo install -q --locked sheldon
 


### PR DESCRIPTION
## 概要

Rustの開発効率を向上させるために、よく使われるcargoツールを追加する。
合わせてインデントをタブからスペースに統一する。

## 変更内容

- `cargo-udeps` - 未使用依存関係の検出
- `cargo-watch` - ファイル変更時の自動ビルド/テスト
- `cargo-nextest` - 高速なテストランナー
- `cargo-audit` - 依存関係の脆弱性チェック
- `cargo-release` - リリース自動化
- インデントをタブからスペースに修正

## 動作確認

- scripts/rust.sh の差分を確認済み