### PR TITLE
chore: add dot_claude configuration with CLAUDE.md and slash commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 # white list
 !/dot_zshenv.tmpl
 !/dot_config/**
+!/dot_claude/**
 
 # github files
 !.gitignore

--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -1,0 +1,16 @@
+# Locale
+
+- Use Japanese for all responses.
+
+# Code style
+
+- Do not use full-width punctuation/symbol characters in code comments or docstrings.
+  - Examples of disallowed full-width symbols: （ ）［ ］｛ ｝＜ ＞「 」『 』【 】、。！？：；・…ー
+  - Use ASCII equivalents instead: () [] {} <> "" '' , . ! ? : ; - ...
+- Japanese words/kanji/kana are allowed; only full-width symbols should be avoided.
+
+# Git
+
+- Before committing, always check the current branch with `git branch --show-current`.
+- If on `main`, do not commit directly. Create a new branch first, then commit.
+  - Example: `git checkout -b feature/your-feature-name`

--- a/dot_claude/commands/commit.md
+++ b/dot_claude/commands/commit.md
@@ -1,0 +1,40 @@
+---
+allow-tools: |
+  Bash(git branch --show-current), Bash(git diff), Bash(git status), Bash(git log:*), Bash(git add .), Bash(git commit -m "*"), Bash(git checkout -b:*)
+  Read(*.ts), Read(*.js), Read(*.py), Read(*.rs), Read(*.go), Read(*.json)
+  Bash(rg:*), Bash(gomi:*), Glob(*), Grep(*), TodoWrite
+description: ブランチを切ってから変更をcommitします。commitはconventional commitに準拠します。
+---
+
+# commit
+
+以下の手順でコミットを行ってください。
+
+## 手順
+
+1. `git diff` と `git status` で変更内容を確認する
+2. 現在のブランチが `main` / `master` の場合は、新たにブランチを作成する（例: `git checkout -b feature/your-feature-name`）
+3. 変更内容を分析し、Conventional Commits形式のコミットメッセージを提案する
+4. 確認を取ってから `git add .` → `git commit -m "<message>"` を実行する
+
+## コミットメッセージのルール
+
+- 形式: `<type>: <description>`
+- descriptionは命令形・現在形で書く（例: `add` / `fix` / `update`）
+
+### タイプ
+
+| タイプ     | 用途                   |
+| ---------- | ---------------------- |
+| `feat`     | 新機能追加             |
+| `fix`      | バグ修正               |
+| `refactor` | リファクタリング       |
+| `chore`    | ビルド・設定・依存関係 |
+| `docs`     | ドキュメントのみ       |
+| `test`     | テストの追加・修正     |
+| `style`    | フォーマット変更       |
+| `perf`     | パフォーマンス改善     |
+
+## 注意
+
+- 複数の独立した変更がある場合は、分割してコミットすることを提案する

--- a/dot_claude/commands/pr.md
+++ b/dot_claude/commands/pr.md
@@ -1,0 +1,60 @@
+---
+allow-tools: |
+  Bash(git branch --show-current), Bash(git diff), Bash(git status), Bash(git log:*), Bash(git add .), Bash(git commit -m "*"), Bash(git checkout -b:*)
+  Read(*.ts), Read(*.js), Read(*.py), Read(*.rs), Read(*.go), Read(*.json)
+  Bash(rg:*), Glob(*), Grep(*), TodoWrite
+description: PRを作成する
+---
+
+
+# pr
+
+以下の手順でPull Requestを作成してください。
+
+## 手順
+
+1. 現在のブランチとベースブランチを確認する
+
+   ```bash
+   git branch --show-current
+   git log main..HEAD --oneline
+   ```
+
+2. `git diff main...HEAD` でmainとの差分を確認する
+
+3. コミット履歴と変更内容からPRの内容を分析し、以下を提案する
+   - **タイトル**: Conventional Commits形式（例: `feat: add hospital-centric TOML config`）
+   - **本文**: 下記テンプレートに沿って記載
+
+4. 確認を取ってから `gh pr create` でPRを作成する
+
+## PRテンプレート
+
+```markdown
+## 概要
+
+<!-- 何をなぜ変更したか -->
+
+## 変更内容
+
+<!-- 主な変更点を箇条書きで -->
+
+## 動作確認
+
+<!-- 確認した内容 -->
+```
+
+## 実行コマンド
+
+```bash
+gh pr create \
+  --title "<title>" \
+  --body "<body>" \
+  --base main
+```
+
+## 注意
+
+- まだリモートにプッシュされていない場合は `git push -u origin <branch>` を先に実行する
+- ベースブランチは通常 `main` だが、リポジトリの設定に合わせて変更する
+- Draft PRにしたい場合は `--draft` フラグを追加する

--- a/dot_claude/commands/version-up.md
+++ b/dot_claude/commands/version-up.md
@@ -1,0 +1,92 @@
+---
+allow-tools: |
+  Bash(git-cliff:*)
+  Bash(git branch --show-current), Bash(git add:*), Bash(git diff), Bash(git status), Bash(git log:*), Bash(git tag:*)
+  Bash(cat:*), Bash(sed:*), Bash(date:*), Bash(grep:*)
+  Read(*), Write(*)
+  Bash(rg:*), Glob(*), Grep(*), TodoWrite
+description: プロジェクトのバージョンを上げます。セマンティックバージョニングと日付ベースバージョニングの両方に対応します
+---
+
+# version up
+
+以下の手順でversion upを行ってください。
+
+## 手順
+
+### 1. 現在の状態を確認
+
+- `git diff` と `git status` で変更内容を確認する
+- `git log --oneline -20` で直近のコミット履歴を確認する
+
+### 2. バージョニング方式を検出
+
+`git tag --sort=-v:refname` で既存のタグ一覧を取得し、バージョニング方式を判別する。
+
+- **セマンティックバージョニング**: `v1.2.3`, `1.2.3` のようなパターン
+- **CalVer (日付ベース)**: `v2024.01.15`, `2024.1`, `24.3.1` のようなパターン
+
+タグが存在しない場合はユーザーにどちらの方式を使うか確認する。
+
+### 3. バージョン管理ファイルを検出
+
+プロジェクトルートから以下のファイルを探し、現在のバージョンを特定する。複数見つかった場合はすべて更新対象とする。
+
+| ファイル | 言語/ツール | バージョン記述箇所 |
+|---|---|---|
+| `Cargo.toml` | Rust | `version = "x.y.z"` (package セクション内。workspace の場合は `[workspace.package]` も確認) |
+| `package.json` | Node.js | `"version": "x.y.z"` |
+| `pyproject.toml` | Python | `version = "x.y.z"` |
+| `setup.py` | Python (legacy) | `version="x.y.z"` |
+| `build.gradle` / `build.gradle.kts` | Java/Kotlin | `version = "x.y.z"` |
+| `pom.xml` | Java (Maven) | `<version>x.y.z</version>` |
+| `mix.exs` | Elixir | `version: "x.y.z"` |
+| `pubspec.yaml` | Dart/Flutter | `version: x.y.z` |
+| `*.gemspec` | Ruby | `spec.version = "x.y.z"` |
+| `version.txt` / `VERSION` | 汎用 | バージョン文字列のみ |
+
+見つからない場合はユーザーにバージョンファイルのパスを確認する。
+
+### 4. 次のバージョンを決定
+
+#### セマンティックバージョニングの場合
+
+変更内容を分析し、以下の基準で判断する:
+
+- **MAJOR** (x.0.0): 破壊的変更 (Breaking Changes) がある場合
+- **MINOR** (x.y.0): 後方互換性のある新機能追加がある場合
+- **PATCH** (x.y.z): バグ修正、ドキュメント更新、リファクタリングなどの場合
+
+#### CalVer (日付ベース) の場合
+
+既存タグのパターンに合わせて日付を生成する:
+
+- `YYYY.MM.DD` / `YYYY.M.D` — 今日の日付
+- `YYYY.MM.patch` — 同月リリースが既にあれば patch 部分をインクリメント
+- その他のパターン — 既存のフォーマットに倣う
+
+### 5. ユーザーに確認
+
+変更先のバージョンについてユーザーの承認を得る。以下を提示すること:
+
+- 現在のバージョン
+- 提案する次のバージョン (と選定理由)
+- 更新対象のファイル一覧
+
+### 6. バージョンファイルを更新
+
+手順3で検出したすべてのファイルのバージョンを更新する。
+
+### 7. CHANGELOG を更新
+
+以下の優先順でCHANGELOGを更新する:
+
+1. **git-cliff が利用可能** (`cliff.toml` や `git-cliff` コマンドが存在): `git-cliff` を使って生成する
+2. **既存の CHANGELOG ファイルがある場合** (`CHANGELOG.md`, `Changes.md`, `HISTORY.md` 等): 手動でエントリを追記する
+3. **どちらもない場合**: ユーザーにCHANGELOGの作成要否を確認する
+
+### 8. コミットとタグ付け
+
+- 変更をコミットする。コミットメッセージは `chore: release vX.Y.Z` とする
+- 既存タグの prefix に合わせてタグを作成する (`v` prefix の有無を揃える)
+- `git push && git push --tags` でリモートに反映する


### PR DESCRIPTION
## 概要

chezmoi管理下に `.claude/` 設定ディレクトリ（`dot_claude/`）を追加する。
CLAUDE.md とスラッシュコマンド群を dotfiles として管理できるようにする。

## 変更内容

- `.gitignore`: `!/dot_claude/**` をホワイトリストに追加
- `dot_claude/CLAUDE.md`: ロケール・コードスタイル・Gitルールを記述
- `dot_claude/commands/commit.md`: Conventional Commits形式でブランチ作成+コミットを行うスラッシュコマンド
- `dot_claude/commands/pr.md`: PRを作成するスラッシュコマンド
- `dot_claude/commands/version-up.md`: セマンティック/CalVerに対応したバージョンアップスラッシュコマンド

## 動作確認

- chezmoi apply 後に `~/.claude/` へ展開されることを確認