### PR TITLE
fix(yazi): add rt.opener compatibility for full-border plugin

### DIFF
--- a/dot_config/yazi/plugins/full-border.yazi/readonly_main.lua
+++ b/dot_config/yazi/plugins/full-border.yazi/readonly_main.lua
@@ -26,16 +26,25 @@ local function setup(_, opts)
 		}
 
 		local style = th.mgr.border_style
-		self._base = ya.list_merge(self._base or {}, {
-			ui.Border(ui.Edge.ALL):area(self._area):type(type):style(style),
-			ui.Bar(ui.Edge.RIGHT):area(self._chunks[1]):style(style),
-			ui.Bar(ui.Edge.LEFT):area(self._chunks[3]):style(style),
+		if rt.opener then -- TODO: remove this compatibility hack
+			self._base = ya.list_merge(self._base or {}, {
+				ui.Border(ui.Edge.ALL):area(self._area):type(type):style(style),
 
-			bar("┬", c[1].right - 1, c[1].y),
-			bar("┴", c[1].right - 1, c[1].bottom - 1),
-			bar("┬", c[2].right, c[2].y),
-			bar("┴", c[2].right, c[2].bottom - 1),
-		})
+				bar("┬", c[2].x, c[1].y),
+				bar("┴", c[2].x, c[1].bottom - 1),
+				bar("┬", c[2].right - 1, c[2].y),
+				bar("┴", c[2].right - 1, c[2].bottom - 1),
+			})
+		else
+			self._base = ya.list_merge(self._base or {}, {
+				ui.Border(ui.Edge.ALL):area(self._area):type(type):style(style),
+
+				bar("┬", c[1].right - 1, c[1].y),
+				bar("┴", c[1].right - 1, c[1].bottom - 1),
+				bar("┬", c[2].right, c[2].y),
+				bar("┴", c[2].right, c[2].bottom - 1),
+			})
+		end
 
 		old_build(self, ...)
 	end


### PR DESCRIPTION
## 概要

yazi の full-border プラグインで `rt.opener` の有無によってボーダーバーの描画位置が異なる問題に対応。
新しいバージョンの yazi では `rt.opener` が存在するため、その場合は異なる座標計算を使用する。

## 変更内容

- `rt.opener` の有無を条件分岐し、それぞれ適切なボーダーバー位置を設定
- 旧バージョン互換のコードは `else` 節に残置（TODO: 将来的に削除予定）
- `ui.Bar` による明示的なバー描画を新バージョンでは削除

## 動作確認

- yazi 起動時にペイン間のボーダーが正しく表示されることを確認