### PR TITLE
fix(ci): replace expired GH_PAT with github.token in workflows

### DIFF
--- a/.github/workflows/arch_manjaro.yml
+++ b/.github/workflows/arch_manjaro.yml
@@ -37,7 +37,7 @@ jobs:
             base-devel pkgconf oniguruma
       - name: Run chezmoi
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: sh -c "$(curl -fsLS chezmoi.io/get)" -- init --apply --branch ${{ env.CURRENT_BRANCH }} radiol
       # # Error Check
       - name: Exec zsh and check sheldon/plugins.lock exist.
@@ -92,7 +92,7 @@ jobs:
             base-devel pkgconf oniguruma
       - name: Run chezmoi
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: sh -c "$(curl -fsLS chezmoi.io/get)" -- init --apply --branch ${{ env.CURRENT_BRANCH }} radiol
       # # Error Check
       - name: Exec zsh and check sheldon/plugins.lock exist.

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -10,7 +10,7 @@ jobs:
   macos-test:
     runs-on: macos-latest
     env:
-      GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+      GITHUB_TOKEN: ${{ github.token }}
       MISE_PYTHON_PRECOMPILED_FLAVOR: install_only_stripped
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Run chezmoi
         shell: bash
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           /bin/bash -c "$(curl -fsLS chezmoi.io/get)" -- init --apply --branch "${{ env.CURRENT_BRANCH }}" radiol


### PR DESCRIPTION
## 概要

GitHub API へのアクセスに使用していた `secrets.GH_PAT`（Personal Access Token）が期限切れとなり、CI で UDEV Gothic フォントのダウンロードが 401 Bad credentials で失敗していた。期限切れ・管理不要な `github.token`（Actions 自動生成トークン）に置き換えることで修正する。

## 変更内容

- `.github/workflows/ubuntu.yml`: `secrets.GH_PAT` → `github.token`
- `.github/workflows/macos.yml`: `secrets.GH_PAT` → `github.token`
- `.github/workflows/arch_manjaro.yml`: `secrets.GH_PAT` → `github.token`（2箇所）

`yuru7/udev-gothic` はパブリックリポジトリのため `github.token` で十分アクセス可能（5,000 req/hour の認証済みレートリミット適用）。

## 動作確認

- `github.token` は各ワークフロー実行時に自動生成され、期限切れが発生しない