### PR TITLE
feat(lazygit): add aicommit2 integration with fzf preview

### DIFF
--- a/dot_config/lazygit/config.yml
+++ b/dot_config/lazygit/config.yml
@@ -1,2 +1,10 @@
 gui:
   showIcons: true
+customCommands:
+  # for aicommit2
+  # Long commit with fzf preview (Shift+C in files panel)
+  - key: "C"
+    context: "files"
+    description: "Generate commit message (long) with aicommit2"
+    output: "terminal"
+    command: "ANTHROPIC_API_KEY=$(gopass show -o api/anthropic/api_key) ~/.config/lazygit/scripts/aicommit_fzf.sh"  # Update with your script path

--- a/dot_config/lazygit/scripts/executable_aicommit_fzf.sh
+++ b/dot_config/lazygit/scripts/executable_aicommit_fzf.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+for cmd in aicommit2 jq fzf; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "$cmd is required"
+    exit 1
+  fi
+done
+
+results_file="$(mktemp -t lazygit-aicommit-results.XXXXXX)"
+trap 'rm -f "$results_file"' EXIT INT TERM
+
+selected="$(
+  echo | fzf \
+    --prompt="AI commit> " \
+    --header="Select a message" \
+    --height=100% \
+    --layout=reverse \
+    --info=inline \
+    --with-nth=2.. \
+    --delimiter=$'\t' \
+    --with-shell="bash --noprofile --norc -c" \
+    --preview-window="right:60%:wrap" \
+    --preview "jq -r '.[ {1} ] | \"\(.subject)\n\n\(.body)\"' $results_file" \
+    --bind "load:unbind(load)+reload-sync#aicommit2 -i --output json 2>/dev/null | jq -s '.' > $results_file && jq -r 'to_entries[] | \"\\(.key)\\t\\(.value.subject)\"' $results_file#"
+)" || exit 0
+
+[ -n "$selected" ] || exit 0
+
+index="${selected%%$'\t'*}"
+subject="$(jq -r ".[$index].subject" "$results_file")"
+body="$(jq -r ".[$index].body" "$results_file")"
+
+git commit -e -m "$subject" -m "$body"


### PR DESCRIPTION
## 概要

lazygit に aicommit2 を使った AI コミットメッセージ生成機能を追加する。
files パネルで `Shift+C` を押すと、aicommit2 が複数のコミットメッセージ候補を生成し、
fzf のプレビュー付きインタフェースで選択・編集できる。

## 変更内容

- `lazygit/config.yml`: `Shift+C` キーバインドのカスタムコマンドを追加
  - gopass から Anthropic API キーを取得して aicommit2 を実行
- `lazygit/scripts/executable_aicommit_fzf.sh`: aicommit2 + fzf 統合スクリプトを追加
  - aicommit2 で JSON 形式の候補を生成し一時ファイルに保存
  - fzf で subject 一覧を表示しつつ右ペインに body をプレビュー
  - 選択後、`git commit -e` でエディタを開いて最終編集できる

## 動作確認

- lazygit の files パネルで `C` (Shift+C) を押して aicommit2 が起動することを確認
- fzf で候補を選択し、コミットが作成されることを確認