### PR TITLE
refactor(lazygit): remove quick commit shortcut for aicommit2

### DIFF
--- a/dot_config/lazygit/config.yml
+++ b/dot_config/lazygit/config.yml
@@ -2,20 +2,6 @@ gui:
   showIcons: true
 customCommands:
   # for aicommit2
-  - key: "c"
-    context: "files"
-    description: "Generate commit message with aicommit2"
-    prompts:
-      - type: "menuFromCommand"
-        title: "Select commit message"
-        key: "Commit"
-        command: "bash -c 'ANTHROPIC_API_KEY=$(gopass show -o api/anthropic/api_key) aicommit2 --output json'"
-        filter: '"subject":"(?P<subject>[^"]+)","body":"(?P<body>[^"]*)"'
-        valueFormat: '{{ .subject }}<SEP>{{ .body }}'
-        labelFormat: '{{ .subject }}'
-    output: "terminal"
-    command: bash -c 'MSG="{{ .Form.Commit }}" && SUBJ="${MSG%%<SEP>*}" && BODY="${MSG#*<SEP>}" && git commit -e -m "$SUBJ" ${BODY:+-m "$BODY"}'
-  # for aicommit2
   # Long commit with fzf preview (Shift+C in files panel)
   - key: "C"
     context: "files"


### PR DESCRIPTION
## 概要

lazygit の `c` キーにバインドされていた aicommit2 クイックコミットコマンドを削除する。
`C` キーの fzf プレビュー付きコマンドに統一するため、重複していた簡易版を除去。

## 変更内容

- `c` キーの aicommit2 クイックコミットカスタムコマンドを削除
  - `menuFromCommand` を使った選択 UI およびコミット実行コマンドを除去
  - `C` キーの fzf プレビュー版が同等の機能を提供するため不要と判断

## 動作確認

- lazygit で `C` キーによる aicommit2 フロー（fzf プレビュー付き）が引き続き動作することを確認