### PR TITLE
chore(git): add gh credential helper for GitHub and Gist

### DIFF
--- a/dot_config/git/config
+++ b/dot_config/git/config
@@ -23,3 +23,9 @@
 	diffFilter = delta --color-only]
 [credential]
 	helper = cache --timeout=3600n
+[credential "https://github.com"]
+	helper = 
+	helper = !gh auth git-credential
+[credential "https://gist.github.com"]
+	helper = 
+	helper = !gh auth git-credential


### PR DESCRIPTION
## 概要

GitHub CLI (`gh`) の credential helper を git config に追加。
`gh auth git-credential` を使うことで、GitHub および Gist への認証を gh の認証情報で行えるようにする。

## 変更内容

- `[credential "https://github.com"]` セクションを追加し、`gh auth git-credential` を helper に設定
- `[credential "https://gist.github.com"]` セクションを追加し、同様に設定

## 動作確認

- git push/pull が gh の認証情報で通ることを確認