### PR TITLE
feat(ci): improve CI failure visibility with error traps and log groups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@
 !/dot_config/**
 !/dot_claude/**
 
+# docs
+!docs/**
+
 # github files
 !.gitignore
 !.github/workflows/*

--- a/docs/superpowers/plans/2026-06-03-ci-failure-visibility.md
+++ b/docs/superpowers/plans/2026-06-03-ci-failure-visibility.md
@@ -1,0 +1,585 @@
+# CI Failure Visibility Improvement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `::error::` ERR traps and `::group::` annotations to all scripts under `scripts/` so GitHub Actions highlights the exact failing line and collapses healthy output.
+
+**Architecture:** Each script gets a single `trap '...' ERR` line after the shebang. Scripts missing `::group::` blocks get them added wrapping the entire body. No shared library — each script is self-contained.
+
+**Tech Stack:** Bash, GitHub Actions log annotations (`::error::`, `::group::`, `::endgroup::`)
+
+---
+
+## File Map
+
+| File | Change |
+|---|---|
+| `scripts/arch.sh` | Add ERR trap + `::group::ArchLinux Mirror Setup` |
+| `scripts/brew.sh` | Add ERR trap + `::group::Homebrew` |
+| `scripts/manjaro.sh` | Add ERR trap + `::group::Manjaro Mirror Setup` |
+| `scripts/darwin.sh` | Add ERR trap only |
+| `scripts/delete-chezmoi.sh` | Add ERR trap only |
+| `scripts/go.sh` | Add ERR trap only |
+| `scripts/mise.sh` | Add ERR trap only |
+| `scripts/pacman.sh` | Add ERR trap only |
+| `scripts/rust.sh` | Add ERR trap only |
+| `scripts/ubuntu.sh` | Add ERR trap only |
+| `scripts/udevgothic.sh` | Add ERR trap only |
+| `scripts/uv.sh` | Add ERR trap only |
+
+---
+
+## Task 1: Add ERR trap + group to arch.sh
+
+**Files:**
+- Modify: `scripts/arch.sh`
+
+- [ ] **Step 1: Rewrite arch.sh with ERR trap and group**
+
+Replace the full content of `scripts/arch.sh` with:
+
+```bash
+#!/bin/bash -xeu
+
+trap 'echo "::error::file=${BASH_SOURCE[0]},line=${LINENO}::Command failed: ${BASH_COMMAND}"' ERR
+
+# ---------------------------------------------------------
+# Set Mirror Server for ArchLinux
+# ---------------------------------------------------------
+echo "::group::ArchLinux Mirror Setup"
+echo "Setting ArchLinux mirror servers"
+mkdir -p ~/.cache
+sudo pacman -Sy -q --noconfirm reflector
+sudo cp /etc/pacman.d/mirrorlist /etc/pacman.d/mirrorlist.bak
+sudo reflector --country "Japan" --latest 5 --completion-percent 95 --protocol https --sort rate --save /etc/pacman.d/mirrorlist
+echo "::endgroup::"
+```
+
+- [ ] **Step 2: Check syntax**
+
+```bash
+bash -n scripts/arch.sh
+```
+
+Expected: no output (syntax OK)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/arch.sh
+git commit -m "feat(ci): add error trap and group to arch.sh"
+```
+
+---
+
+## Task 2: Add ERR trap + group to manjaro.sh
+
+**Files:**
+- Modify: `scripts/manjaro.sh`
+
+- [ ] **Step 1: Rewrite manjaro.sh with ERR trap and group**
+
+Replace the full content of `scripts/manjaro.sh` with:
+
+```bash
+#!/bin/bash -xeu
+
+trap 'echo "::error::file=${BASH_SOURCE[0]},line=${LINENO}::Command failed: ${BASH_COMMAND}"' ERR
+
+# ---------------------------------------------------------
+# Set Mirror Server for Manjaro
+# ---------------------------------------------------------
+echo "::group::Manjaro Mirror Setup"
+echo "Setting Manjaro mirror servers"
+mkdir -p ~/.cache
+sudo pacman-mirrors -c Japan
+sudo pacman-mirrors --fasttrack
+echo "::endgroup::"
+```
+
+- [ ] **Step 2: Check syntax**
+
+```bash
+bash -n scripts/manjaro.sh
+```
+
+Expected: no output (syntax OK)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/manjaro.sh
+git commit -m "feat(ci): add error trap and group to manjaro.sh"
+```
+
+---
+
+## Task 3: Add ERR trap + group to brew.sh
+
+**Files:**
+- Modify: `scripts/brew.sh`
+
+- [ ] **Step 1: Rewrite brew.sh with ERR trap and group**
+
+Replace the full content of `scripts/brew.sh` with:
+
+```bash
+#!/bin/bash -xeu
+
+trap 'echo "::error::file=${BASH_SOURCE[0]},line=${LINENO}::Command failed: ${BASH_COMMAND}"' ERR
+
+# ---------------------------------------------------------
+# Install Homebrew
+# ---------------------------------------------------------
+echo "::group::Homebrew"
+
+# Check Homebrew
+if ! (type "brew" >/dev/null 2>&1); then
+  # Install Homebrew
+  echo "Installing Homebrew"
+  NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+  # Activate Homebrew path
+  if [[ -d "/opt/homebrew" ]]; then
+    HOMEBREW_HOME="/opt/homebrew"
+  elif [[ -d "/home/linuxbrew/.linuxbrew" ]]; then
+    HOMEBREW_HOME="/home/linuxbrew/.linuxbrew"
+  else
+    HOMEBREW_HOME="/usr/local"
+  fi
+  eval "$("$HOMEBREW_HOME"/bin/brew shellenv)"
+fi
+
+# ---------------------------------------------------------
+# Clean up Homebrew
+# ---------------------------------------------------------
+echo "Cleaning up Homebrew"
+brew uninstall --ignore-dependencies cmake || true
+brew update-reset && brew update
+
+# ---------------------------------------------------------
+# Install Homebrew Apps
+# ---------------------------------------------------------
+echo "Installing Homebrew Apps"
+brew install -q --cask font-hack-nerd-font
+brew install -q \
+  aicommit2 \
+  cmake \
+  direnv \
+  fd \
+  fzf \
+  git \
+  go \
+  gopass \
+  jq \
+  lazygit \
+  luarocks \
+  neovim \
+  node \
+  openssl@3 \
+  readline \
+  sqlite3 \
+  tcl-tk \
+  xclip \
+  xz \
+  zlib \
+  zsh
+
+echo "::endgroup::"
+```
+
+- [ ] **Step 2: Check syntax**
+
+```bash
+bash -n scripts/brew.sh
+```
+
+Expected: no output (syntax OK)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/brew.sh
+git commit -m "feat(ci): add error trap and group to brew.sh"
+```
+
+---
+
+## Task 4: Add ERR trap to darwin.sh
+
+**Files:**
+- Modify: `scripts/darwin.sh`
+
+- [ ] **Step 1: Insert ERR trap after shebang**
+
+In `scripts/darwin.sh`, insert the following line after `#!/bin/bash -xeu` (line 1):
+
+```bash
+trap 'echo "::error::file=${BASH_SOURCE[0]},line=${LINENO}::Command failed: ${BASH_COMMAND}"' ERR
+```
+
+The file should begin:
+
+```bash
+#!/bin/bash -xeu
+
+trap 'echo "::error::file=${BASH_SOURCE[0]},line=${LINENO}::Command failed: ${BASH_COMMAND}"' ERR
+
+# ---------------------------------------------------------
+# Install Homebrew
+# ---------------------------------------------------------
+echo "::group::Homebrew"
+```
+
+- [ ] **Step 2: Check syntax**
+
+```bash
+bash -n scripts/darwin.sh
+```
+
+Expected: no output (syntax OK)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/darwin.sh
+git commit -m "feat(ci): add error trap to darwin.sh"
+```
+
+---
+
+## Task 5: Add ERR trap to delete-chezmoi.sh
+
+**Files:**
+- Modify: `scripts/delete-chezmoi.sh`
+
+- [ ] **Step 1: Insert ERR trap after shebang**
+
+In `scripts/delete-chezmoi.sh`, insert after `#!/bin/bash -xeu`:
+
+```bash
+trap 'echo "::error::file=${BASH_SOURCE[0]},line=${LINENO}::Command failed: ${BASH_COMMAND}"' ERR
+```
+
+The file should begin:
+
+```bash
+#!/bin/bash -xeu
+
+trap 'echo "::error::file=${BASH_SOURCE[0]},line=${LINENO}::Command failed: ${BASH_COMMAND}"' ERR
+
+# ----------------------------------------------------------------------------
+# Remove chezmoi
+# ----------------------------------------------------------------------------
+```
+
+- [ ] **Step 2: Check syntax**
+
+```bash
+bash -n scripts/delete-chezmoi.sh
+```
+
+Expected: no output (syntax OK)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/delete-chezmoi.sh
+git commit -m "feat(ci): add error trap to delete-chezmoi.sh"
+```
+
+---
+
+## Task 6: Add ERR trap to go.sh
+
+**Files:**
+- Modify: `scripts/go.sh`
+
+- [ ] **Step 1: Insert ERR trap after shebang**
+
+In `scripts/go.sh`, insert after `#!/bin/bash -xeu`:
+
+```bash
+trap 'echo "::error::file=${BASH_SOURCE[0]},line=${LINENO}::Command failed: ${BASH_COMMAND}"' ERR
+```
+
+The file should begin:
+
+```bash
+#!/bin/bash -xeu
+
+trap 'echo "::error::file=${BASH_SOURCE[0]},line=${LINENO}::Command failed: ${BASH_COMMAND}"' ERR
+
+echo "::group::Install go apps"
+```
+
+- [ ] **Step 2: Check syntax**
+
+```bash
+bash -n scripts/go.sh
+```
+
+Expected: no output (syntax OK)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/go.sh
+git commit -m "feat(ci): add error trap to go.sh"
+```
+
+---
+
+## Task 7: Add ERR trap to mise.sh
+
+**Files:**
+- Modify: `scripts/mise.sh`
+
+- [ ] **Step 1: Insert ERR trap after shebang**
+
+In `scripts/mise.sh`, insert after `#!/bin/bash -xeu`:
+
+```bash
+trap 'echo "::error::file=${BASH_SOURCE[0]},line=${LINENO}::Command failed: ${BASH_COMMAND}"' ERR
+```
+
+The file should begin:
+
+```bash
+#!/bin/bash -xeu
+
+trap 'echo "::error::file=${BASH_SOURCE[0]},line=${LINENO}::Command failed: ${BASH_COMMAND}"' ERR
+
+# ---------------------------------------------------------
+# Install Mise
+# ---------------------------------------------------------
+echo "::group::Install Mise"
+```
+
+- [ ] **Step 2: Check syntax**
+
+```bash
+bash -n scripts/mise.sh
+```
+
+Expected: no output (syntax OK)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/mise.sh
+git commit -m "feat(ci): add error trap to mise.sh"
+```
+
+---
+
+## Task 8: Add ERR trap to pacman.sh
+
+**Files:**
+- Modify: `scripts/pacman.sh`
+
+- [ ] **Step 1: Insert ERR trap after shebang**
+
+In `scripts/pacman.sh`, insert after `#!/bin/bash -xeu`:
+
+```bash
+trap 'echo "::error::file=${BASH_SOURCE[0]},line=${LINENO}::Command failed: ${BASH_COMMAND}"' ERR
+```
+
+The file should begin:
+
+```bash
+#!/bin/bash -xeu
+
+trap 'echo "::error::file=${BASH_SOURCE[0]},line=${LINENO}::Command failed: ${BASH_COMMAND}"' ERR
+
+# ---------------------------------------------------------
+# Setup Pacman
+# ---------------------------------------------------------
+echo "::group:: Pacman Install Apps"
+```
+
+- [ ] **Step 2: Check syntax**
+
+```bash
+bash -n scripts/pacman.sh
+```
+
+Expected: no output (syntax OK)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/pacman.sh
+git commit -m "feat(ci): add error trap to pacman.sh"
+```
+
+---
+
+## Task 9: Add ERR trap to rust.sh
+
+**Files:**
+- Modify: `scripts/rust.sh`
+
+- [ ] **Step 1: Insert ERR trap after shebang**
+
+In `scripts/rust.sh`, insert after `#!/bin/bash -xeu`:
+
+```bash
+trap 'echo "::error::file=${BASH_SOURCE[0]},line=${LINENO}::Command failed: ${BASH_COMMAND}"' ERR
+```
+
+The file should begin:
+
+```bash
+#!/bin/bash -xeu
+
+trap 'echo "::error::file=${BASH_SOURCE[0]},line=${LINENO}::Command failed: ${BASH_COMMAND}"' ERR
+
+# ---------------------------------------------------------
+# Install Rust
+# ---------------------------------------------------------
+echo "::group::Install Rust"
+```
+
+- [ ] **Step 2: Check syntax**
+
+```bash
+bash -n scripts/rust.sh
+```
+
+Expected: no output (syntax OK)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/rust.sh
+git commit -m "feat(ci): add error trap to rust.sh"
+```
+
+---
+
+## Task 10: Add ERR trap to ubuntu.sh
+
+**Files:**
+- Modify: `scripts/ubuntu.sh`
+
+- [ ] **Step 1: Insert ERR trap after shebang**
+
+In `scripts/ubuntu.sh`, insert after `#!/bin/bash -xeu`:
+
+```bash
+trap 'echo "::error::file=${BASH_SOURCE[0]},line=${LINENO}::Command failed: ${BASH_COMMAND}"' ERR
+```
+
+The file should begin:
+
+```bash
+#!/bin/bash -xeu
+
+trap 'echo "::error::file=${BASH_SOURCE[0]},line=${LINENO}::Command failed: ${BASH_COMMAND}"' ERR
+
+# ---------------------------------------------------------
+# Install apps for Ubuntu
+# ---------------------------------------------------------
+echo "::group::Ubuntu Install Apps"
+```
+
+- [ ] **Step 2: Check syntax**
+
+```bash
+bash -n scripts/ubuntu.sh
+```
+
+Expected: no output (syntax OK)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/ubuntu.sh
+git commit -m "feat(ci): add error trap to ubuntu.sh"
+```
+
+---
+
+## Task 11: Add ERR trap to udevgothic.sh
+
+**Files:**
+- Modify: `scripts/udevgothic.sh`
+
+- [ ] **Step 1: Insert ERR trap after shebang**
+
+In `scripts/udevgothic.sh`, insert after `#!/bin/bash -xeu`:
+
+```bash
+trap 'echo "::error::file=${BASH_SOURCE[0]},line=${LINENO}::Command failed: ${BASH_COMMAND}"' ERR
+```
+
+The file should begin:
+
+```bash
+#!/bin/bash -xeu
+
+trap 'echo "::error::file=${BASH_SOURCE[0]},line=${LINENO}::Command failed: ${BASH_COMMAND}"' ERR
+
+echo "::group::UDEV Gothic Font"
+```
+
+- [ ] **Step 2: Check syntax**
+
+```bash
+bash -n scripts/udevgothic.sh
+```
+
+Expected: no output (syntax OK)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/udevgothic.sh
+git commit -m "feat(ci): add error trap to udevgothic.sh"
+```
+
+---
+
+## Task 12: Add ERR trap to uv.sh
+
+**Files:**
+- Modify: `scripts/uv.sh`
+
+- [ ] **Step 1: Insert ERR trap after shebang**
+
+In `scripts/uv.sh`, insert after `#!/bin/bash -xeu`:
+
+```bash
+trap 'echo "::error::file=${BASH_SOURCE[0]},line=${LINENO}::Command failed: ${BASH_COMMAND}"' ERR
+```
+
+The file should begin:
+
+```bash
+#!/bin/bash -xeu
+
+trap 'echo "::error::file=${BASH_SOURCE[0]},line=${LINENO}::Command failed: ${BASH_COMMAND}"' ERR
+
+# ---------------------------------------------------------
+# Install uv
+# ---------------------------------------------------------
+
+echo "::group::Install uv"
+```
+
+- [ ] **Step 2: Check syntax**
+
+```bash
+bash -n scripts/uv.sh
+```
+
+Expected: no output (syntax OK)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/uv.sh
+git commit -m "feat(ci): add error trap to uv.sh"
+```

--- a/docs/superpowers/specs/2026-06-03-ci-failure-visibility-design.md
+++ b/docs/superpowers/specs/2026-06-03-ci-failure-visibility-design.md
@@ -1,0 +1,67 @@
+# CI Failure Visibility Improvement
+
+**Date:** 2026-06-03
+**Status:** Approved
+
+## Problem
+
+`chezmoi init --apply` runs all installation scripts in a single CI step, producing large log output. When a failure occurs, it is difficult to identify which script and which line caused the failure in the GitHub Actions UI.
+
+## Goal
+
+- Make the failing script and line immediately visible in the GitHub Actions UI
+- Collapse healthy script output so failures stand out
+
+## Approach
+
+Add two GitHub Actions annotations to every script under `scripts/`:
+
+1. **`::error::` trap** - outputs a red annotation with the file name, line number, and failing command when `set -e` triggers an exit
+2. **`::group::` / `::endgroup::` blocks** - collapses script output so only failing groups remain expanded
+
+## ERR Trap Pattern
+
+Insert immediately after the shebang, before any `::group::` line:
+
+```bash
+trap 'echo "::error::file=${BASH_SOURCE[0]},line=${LINENO}::Command failed: ${BASH_COMMAND}"' ERR
+```
+
+GitHub Actions renders this as a red annotation:
+
+```
+Command failed: sudo reflector --country "Japan" ...
+  arch.sh line 9
+```
+
+## Per-Script Changes
+
+| Script | ERR trap | ::group:: added |
+|---|---|---|
+| `arch.sh` | yes | yes - "ArchLinux Mirror Setup" |
+| `brew.sh` | yes | yes - "Homebrew" |
+| `manjaro.sh` | yes | yes - "Manjaro Mirror Setup" |
+| `darwin.sh` | yes | no (already has "Homebrew") |
+| `go.sh` | yes | no (already has "Install go apps") |
+| `mise.sh` | yes | no (already has two groups) |
+| `pacman.sh` | yes | no (already has "Pacman Install Apps") |
+| `rust.sh` | yes | no (already has "Install Rust") |
+| `ubuntu.sh` | yes | no (already has "Ubuntu Install Apps") |
+| `udevgothic.sh` | yes | no (already has "UDEV Gothic Font") |
+| `uv.sh` | yes | no (already has "Install uv") |
+| `delete-chezmoi.sh` | yes | no (simple cleanup, no group needed) |
+
+## Expected UI Behavior
+
+**On success:** Each script's output is collapsed under its group heading.
+
+**On failure:**
+- The failing group stays expanded
+- A red `::error::` annotation appears with the exact file and line number
+- Healthy groups remain collapsed above
+
+## Out of Scope
+
+- Job Summary output (not needed given the above annotations)
+- Workflow restructuring (splitting `chezmoi init --apply` into separate steps)
+- Notification changes

--- a/scripts/arch.sh
+++ b/scripts/arch.sh
@@ -1,10 +1,14 @@
 #!/bin/bash -xeu
 
+trap 'echo "::error::file=${BASH_SOURCE[0]},line=${LINENO}::Command failed: ${BASH_COMMAND}"' ERR
+
 # ---------------------------------------------------------
 # Set Mirror Server for ArchLinux
 # ---------------------------------------------------------
+echo "::group::ArchLinux Mirror Setup"
 echo "Setting ArchLinux mirror servers"
 mkdir -p ~/.cache
 sudo pacman -Sy -q --noconfirm reflector
 sudo cp /etc/pacman.d/mirrorlist /etc/pacman.d/mirrorlist.bak
 sudo reflector --country "Japan" --latest 5 --completion-percent 95 --protocol https --sort rate --save /etc/pacman.d/mirrorlist
+echo "::endgroup::"

--- a/scripts/arch.sh
+++ b/scripts/arch.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -xeu
 
-trap 'echo "::error::file=${BASH_SOURCE[0]},line=${LINENO}::Command failed: ${BASH_COMMAND}"' ERR
+trap 'echo "::error file=${BASH_SOURCE[0]},line=${LINENO}::Command failed: ${BASH_COMMAND}"' ERR
 
 # ---------------------------------------------------------
 # Set Mirror Server for ArchLinux

--- a/scripts/brew.sh
+++ b/scripts/brew.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -xeu
 
-trap 'echo "::error::file=${BASH_SOURCE[0]},line=${LINENO}::Command failed: ${BASH_COMMAND}"' ERR
+trap 'echo "::error file=${BASH_SOURCE[0]},line=${LINENO}::Command failed: ${BASH_COMMAND}"' ERR
 
 # ---------------------------------------------------------
 # Install Homebrew

--- a/scripts/brew.sh
+++ b/scripts/brew.sh
@@ -1,8 +1,12 @@
 #!/bin/bash -xeu
 
+trap 'echo "::error::file=${BASH_SOURCE[0]},line=${LINENO}::Command failed: ${BASH_COMMAND}"' ERR
+
 # ---------------------------------------------------------
 # Install Homebrew
 # ---------------------------------------------------------
+echo "::group::Homebrew"
+
 # Check Homebrew
 if ! (type "brew" >/dev/null 2>&1); then
   # Install Homebrew
@@ -54,3 +58,5 @@ brew install -q \
   xz \
   zlib \
   zsh
+
+echo "::endgroup::"

--- a/scripts/darwin.sh
+++ b/scripts/darwin.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -xeu
 
+trap 'echo "::error file=${BASH_SOURCE[0]},line=${LINENO}::Command failed: ${BASH_COMMAND}"' ERR
+
 # ---------------------------------------------------------
 # Install Homebrew
 # ---------------------------------------------------------

--- a/scripts/delete-chezmoi.sh
+++ b/scripts/delete-chezmoi.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -xeu
 
+trap 'echo "::error file=${BASH_SOURCE[0]},line=${LINENO}::Command failed: ${BASH_COMMAND}"' ERR
+
 # ----------------------------------------------------------------------------
 # Remove chezmoi
 # ----------------------------------------------------------------------------

--- a/scripts/go.sh
+++ b/scripts/go.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -xeu
 
+trap 'echo "::error file=${BASH_SOURCE[0]},line=${LINENO}::Command failed: ${BASH_COMMAND}"' ERR
+
 echo "::group::Install go apps"
 
 # Check go is available

--- a/scripts/manjaro.sh
+++ b/scripts/manjaro.sh
@@ -1,9 +1,13 @@
 #!/bin/bash -xeu
 
+trap 'echo "::error::file=${BASH_SOURCE[0]},line=${LINENO}::Command failed: ${BASH_COMMAND}"' ERR
+
 # ---------------------------------------------------------
 # Set Mirror Server for Manjaro
 # ---------------------------------------------------------
+echo "::group::Manjaro Mirror Setup"
 echo "Setting Manjaro mirror servers"
 mkdir -p ~/.cache
 sudo pacman-mirrors -c Japan
 sudo pacman-mirrors --fasttrack
+echo "::endgroup::"

--- a/scripts/manjaro.sh
+++ b/scripts/manjaro.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -xeu
 
-trap 'echo "::error::file=${BASH_SOURCE[0]},line=${LINENO}::Command failed: ${BASH_COMMAND}"' ERR
+trap 'echo "::error file=${BASH_SOURCE[0]},line=${LINENO}::Command failed: ${BASH_COMMAND}"' ERR
 
 # ---------------------------------------------------------
 # Set Mirror Server for Manjaro

--- a/scripts/mise.sh
+++ b/scripts/mise.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -xeu
 
+trap 'echo "::error file=${BASH_SOURCE[0]},line=${LINENO}::Command failed: ${BASH_COMMAND}"' ERR
+
 # ---------------------------------------------------------
 # Install Mise
 # ---------------------------------------------------------

--- a/scripts/pacman.sh
+++ b/scripts/pacman.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -xeu
 
+trap 'echo "::error file=${BASH_SOURCE[0]},line=${LINENO}::Command failed: ${BASH_COMMAND}"' ERR
+
 # ---------------------------------------------------------
 # Setup Pacman
 # ---------------------------------------------------------

--- a/scripts/rust.sh
+++ b/scripts/rust.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -xeu
 
+trap 'echo "::error file=${BASH_SOURCE[0]},line=${LINENO}::Command failed: ${BASH_COMMAND}"' ERR
+
 # ---------------------------------------------------------
 # Install Rust
 # ---------------------------------------------------------

--- a/scripts/ubuntu.sh
+++ b/scripts/ubuntu.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -xeu
 
+trap 'echo "::error file=${BASH_SOURCE[0]},line=${LINENO}::Command failed: ${BASH_COMMAND}"' ERR
+
 # ---------------------------------------------------------
 # Install apps for Ubuntu
 # ---------------------------------------------------------

--- a/scripts/udevgothic.sh
+++ b/scripts/udevgothic.sh
@@ -1,4 +1,7 @@
 #!/bin/bash -xeu
+
+trap 'echo "::error file=${BASH_SOURCE[0]},line=${LINENO}::Command failed: ${BASH_COMMAND}"' ERR
+
 echo "::group::UDEV Gothic Font"
 echo "Installing Udev Gothic Fonts"
 

--- a/scripts/uv.sh
+++ b/scripts/uv.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -xeu
 
+trap 'echo "::error file=${BASH_SOURCE[0]},line=${LINENO}::Command failed: ${BASH_COMMAND}"' ERR
+
 # ---------------------------------------------------------
 # Install uv
 # ---------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `::error file=...,line=...::` ERR trap to all 12 scripts under `scripts/` so GitHub Actions highlights the exact failing line in red when `chezmoi init --apply` fails
- Add `::group::` / `::endgroup::` to `arch.sh`, `brew.sh`, and `manjaro.sh` (the 3 scripts that were missing them) to collapse healthy output
- Fix existing scripts to use correct GitHub Actions annotation syntax (`::error ` with space, not `::error::`)

## Test Plan

- [ ] Verify all scripts pass `bash -n` syntax check (done locally: all pass)
- [ ] Trigger CI on this PR and confirm `chezmoi init --apply` step logs are grouped correctly
- [ ] Optionally introduce a deliberate failure to confirm `::error` annotation appears with file/line info