### PR TITLE
fix(ci): collapse MasonToolsInstall log output with ::group:: annotation

### DIFF
--- a/.github/workflows/arch_manjaro.yml
+++ b/.github/workflows/arch_manjaro.yml
@@ -53,7 +53,9 @@ jobs:
         shell: bash
         run: |
           eval "$($HOME/.local/bin/mise activate bash)"
+          echo "::group::MasonToolsInstall"
           nvim --headless "+MasonToolsInstall" +qa
+          echo "::endgroup::"
           ls ~/.local/share/nvim/lazy/
       - name: Check go app(gomi) is available
         run: |
@@ -108,7 +110,9 @@ jobs:
         shell: bash
         run: |
           eval "$($HOME/.local/bin/mise activate bash)"
+          echo "::group::MasonToolsInstall"
           nvim --headless "+MasonToolsInstall" +qa
+          echo "::endgroup::"
           ls ~/.local/share/nvim/lazy/
       - name: Check go app(gomi) is available
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -50,7 +50,9 @@ jobs:
         run: |
           set -euo pipefail
           eval "$($HOME/.local/bin/mise activate bash)"
+          echo "::group::MasonToolsInstall"
           nvim --headless "+MasonToolsInstall" +qa
+          echo "::endgroup::"
           ls "$HOME/.local/share/nvim/lazy/"
       - name: Check go app(gomi) is available
         shell: bash

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -61,7 +61,9 @@ jobs:
         run: |
           set -euo pipefail
           eval "$($HOME/.local/bin/mise activate bash)"
+          echo "::group::MasonToolsInstall"
           nvim --headless "+MasonToolsInstall" +qa
+          echo "::endgroup::"
           ls "$HOME/.local/share/nvim/lazy/"
 
       - name: Check go app(gomi) is available


### PR DESCRIPTION
## Summary

- Wrap `nvim --headless "+MasonToolsInstall" +qa` in `::group::MasonToolsInstall` / `::endgroup::` in all 3 workflows
- Mason progress updates (% counters) are printed as separate lines in CI because there is no TTY to handle `\r` in-place rewrites — the group collapses this noise while keeping the output accessible if needed
- The `ls` check after the command remains visible in the main step log

## Test Plan

- [ ] Confirm `Check lazy.nvim dir` step shows a collapsed `▶ MasonToolsInstall` sub-group in CI logs
- [ ] Confirm `ls` output (lazy.nvim dir listing) is still visible outside the group