### PR TITLE
feat: enable pre_sudo for topgrade on Linux

### DIFF
--- a/dot_config/topgrade.toml.tmpl
+++ b/dot_config/topgrade.toml.tmpl
@@ -20,6 +20,9 @@ no_retry = true
 # Run `sudo -v` to cache credentials at the start of the run; this avoids a
 # blocking password prompt in the middle of a possibly-unattended run.
 # pre_sudo = false
+{{ if eq .chezmoi.os "linux" }}
+pre_sudo = true
+{{ end }}
 
 # Run inside tmux
 #run_in_tmux = true


### PR DESCRIPTION
## 概要

Linux環境でのtopgrade実行時に `pre_sudo = true` を有効化する。
Linuxでは実行中にsudoパスワードを要求されブロックされる可能性があるため、
実行開始時にcredentialをキャッシュさせる。

## 変更内容

- `dot_config/topgrade.toml.tmpl` にLinux向けの `pre_sudo = true` 設定を追加
  - chezmoisのテンプレート条件分岐 `{{ if eq .chezmoi.os "linux" }}` で制御

## 動作確認

- テンプレートの構文確認済み