### PR TITLE
fix(yazi): update theme.toml for yazi v26 compatibility

### DIFF
--- a/dot_config/yazi/theme.toml
+++ b/dot_config/yazi/theme.toml
@@ -16,7 +16,6 @@ marker_selected = { fg = "#8caaee", bg = "#8caaee" }
 
 tab_active = { fg = "#303446", bg = "#c6d0f5" }
 tab_inactive = { fg = "#c6d0f5", bg = "#51576d" }
-tab_width = 1
 
 count_copied = { fg = "#303446", bg = "#a6d189" }
 count_cut = { fg = "#303446", bg = "#e78284" }
@@ -112,8 +111,8 @@ rules = [
   { mime = "application/{pdf,doc,rtf}", fg = "#a6d189" },
 
   # Fallback
-  { name = "*", fg = "#c6d0f5" },
-  { name = "*/", fg = "#8caaee" },
+  { url = "*", fg = "#c6d0f5" },
+  { url = "*/", fg = "#8caaee" },
 ]
 
 [spot]


### PR DESCRIPTION
## 概要

yazi v26 のスキーマ変更に対応するため theme.toml を修正する。
v26 より `[filetype]` ルールで `name` キーが廃止され `url` / `mime` のみ有効となり、
`tab_width` も `theme.toml` から削除された。

## 変更内容

- `[filetype]` フォールバックルールの `name = "*"` → `url = "*"` に変更
- `tab_width = 1` を削除（v26 で廃止）

## 動作確認

- `yazi --version` が TOML エラーなく起動することを確認